### PR TITLE
add service worker registering for pwa eligibility

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -2,5 +2,8 @@ import React from "react";
 import ReactDOM from "react-dom";
 import App from "./scenes/App";
 import './storage';
+import * as serviceWorker from './serviceWorker';
 
 ReactDOM.render(<App />, document.getElementById("root"));
+
+serviceWorker.register();


### PR DESCRIPTION
Registering a service worker was enough for pwa eligibility. Can't test it locally because of https.

Here's the lighthouse pwa checklist (with https as the only thing missing):

![js-tldr-pwa](https://user-images.githubusercontent.com/20396367/69894467-77eb1e00-1320-11ea-928d-f191790c0747.png)

