### PR TITLE
Rectify error in example of Array.proto.slice

### DIFF
--- a/public/docs/Array/slice.md
+++ b/public/docs/Array/slice.md
@@ -14,7 +14,7 @@ const newArray = originalArray.slice(beginIndex, endIndex);
 ```js
 [1, 2, 3].slice(); // -> [1, 2, 3]
 [1, 2, 3, 4, 5].slice(2); // -> [3, 4, 5]
-[1, 2, 3, 4, 5].slice(2, 3); // -> [3, 4]
+[1, 2, 3, 4, 5].slice(2, 3); // -> [3]
 ```
 
 ---


### PR DESCRIPTION
The second parameter of _slice_ does not include the element of that index.