### PR TITLE
Add missing comma to Array.forEach code snippet

### DIFF
--- a/public/docs/Array/forEach.md
+++ b/public/docs/Array/forEach.md
@@ -5,7 +5,7 @@ The **`forEach`** method executes a provided `function` once for each `array` el
 ## Syntax
 
 ```js
-array.forEach((currentValue index,  array) => {}, thisArg);
+array.forEach((currentValue, index,  array) => {}, thisArg);
 ```
 
 ## Usage examples


### PR DESCRIPTION
The code snippet for Array.prototype.forEach is missing a comma between `currentValue` and `index`. This PR adds this comma.